### PR TITLE
feat: ignore replace picomatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ vscode extension for generate call graph in [graphviz dot language](https://www.
 1. Open your folder and select a entry function
 2. Run `CallGraph.showOutgoingCallGraph` command using `Ctrl+Shift+P` or context menu to show outgoing calls
 3. Or Run `CallGraph.showIncomingCallGraph` command using `Ctrl+Shift+P` or context menu to show incoming calls
+4. Add `.callgraphignore` file in your project root directory to ignore some files or folders
 
 ## How it works
 It depends `vscode.provideOutgoingCalls` and `vscode.provideIncomingCalls` built-in commands.

--- a/package.json
+++ b/package.json
@@ -92,6 +92,6 @@
         "dot"
     ],
     "dependencies": {
-        "picomatch": "^2.3.1"
+        "ignore": "^5.2.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.0",
         "@types/node": "14.x",
-        "@types/picomatch": "^2.3.0",
         "@types/vscode": "^1.65.0",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,6 +762,11 @@ ignore@^5.1.8, ignore@^5.2.0:
   resolved "https://registry.npmmirror.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
+ignore@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.npmmirror.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,11 +90,6 @@
   resolved "https://registry.npmmirror.com/@types/node/-/node-14.18.12.tgz#0d4557fd3b94497d793efd4e7d92df2f83b4ef24"
   integrity sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==
 
-"@types/picomatch@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.npmmirror.com/@types/picomatch/-/picomatch-2.3.0.tgz#75db5e75a713c5a83d5b76780c3da84a82806003"
-  integrity sha512-O397rnSS9iQI4OirieAtsDqvCj4+3eY1J+EPdNTKuHuRWIfUoGyzX294o8C4KJYaLqgSrd2o60c5EqCU8Zv02g==
-
 "@types/vscode@^1.65.0":
   version "1.65.0"
   resolved "https://registry.npmmirror.com/@types/vscode/-/vscode-1.65.0.tgz#042dd8d93c32ac62cb826cd0fa12376069d1f448"


### PR DESCRIPTION
1. 之前的 `.callgraphignore`并未按照预期工作，使用ignore替换了`picomatch`；
2. 限制了`call-graph`只对当前项目内的文件生效
3. 增加了README中ignore的说明