### PR TITLE
Add max depth configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ vscode extension for generate call graph in [graphviz dot language](https://www.
 4. Click `save dot file` or `save as svg` in the bottom left corner to save the graph
 5. Add `.callgraphignore` file in your project root directory to ignore some files or folders in workspace (the syntax is the same as `.gitignore`)
 
+## Extra configuration
+- **Max depth**: You can set the max depth at the `Call-graph: Max Depth` setting in the editor settings session. Note that it applies for both incoming and outgoing call graphs.
+
 ## How it works
 It depends `vscode.provideOutgoingCalls` and `vscode.provideIncomingCalls` built-in commands( the same with `Show Call Hierarchy` command, not available for some language server ).
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
                     "type": "string",
                     "default": "${workspace}/.callgraphignore",
                     "description": "the file that specific paths should ignore"
+                },
+                "call-graph.maxDepth": {
+                    "type": "number",
+                    "default": "0",
+                    "description": "the graph max depth. Set to 0 for unlimited depth"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
                 },
                 "call-graph.maxDepth": {
                     "type": "number",
-                    "default": "0",
+                    "default": 0,
                     "description": "the graph max depth. Set to 0 for unlimited depth"
                 }
             }

--- a/src/call.ts
+++ b/src/call.ts
@@ -49,7 +49,7 @@ async function getCallNode(
             if (isSkip) continue
             const child = { item: next, children: [] }
             node.children.push(child)
-            await insertNode(child, depth += 1)
+            await insertNode(child, depth + 1)
         }
     }
     const graph = { item: entryItem, children: [] as CallHierarchyNode[] }

--- a/src/call.ts
+++ b/src/call.ts
@@ -12,11 +12,15 @@ async function getCallNode(
     ignore: (item: vscode.CallHierarchyItem) => boolean,
     outgoing: Boolean = true
 ) {
+    const maxDepth = vscode.workspace
+        .getConfiguration()
+        .get<number>('call-graph.maxDepth') || 0
     const command = outgoing
         ? 'vscode.provideOutgoingCalls'
         : 'vscode.provideIncomingCalls'
     const nodes = new Set<CallHierarchyNode>()
-    const insertNode = async (node: CallHierarchyNode) => {
+    const insertNode = async (node: CallHierarchyNode, depth=0) => {
+        if (maxDepth > 0 && depth >= maxDepth) return
         output.appendLine('resolve: ' + node.item.name)
         nodes.add(node)
         const calls:
@@ -45,7 +49,7 @@ async function getCallNode(
             if (isSkip) continue
             const child = { item: next, children: [] }
             node.children.push(child)
-            await insertNode(child)
+            await insertNode(child, depth += 1)
         }
     }
     const graph = { item: entryItem, children: [] as CallHierarchyNode[] }


### PR DESCRIPTION
## Summary
Add a Max Depth setting that controls the max depth for the graph. The default value "0" means it's limitless.

<img src="https://github.com/beicause/call-graph/assets/28119777/21a95b81-4ede-4366-9400-9d45ca884126" alt="drawing" width="300"/>

## Changes
- **Add max depth configuration**
- **Add readme section**

## Testing
### Reproducing
1. Generate a build for the branch. I'll skip the details for this section.
2. Add the testing code added at the end of this section.
3. Try different max depth values and generate both outgoing and incoming call-graphs.

### Evidences
<img src="https://github.com/beicause/call-graph/assets/28119777/a5376da1-fada-417b-832b-e324e756bbbf" alt="drawing" width="200"/>
<img src="https://github.com/beicause/call-graph/assets/28119777/6efd4985-778c-4c69-bf3a-bf3576f29bba" alt="drawing" width="200"/>
<img src="https://github.com/beicause/call-graph/assets/28119777/d62c3eb4-cc97-4b48-b0fe-b2772f1cb59f" alt="drawing" width="200"/>

### Test code
```typescript
function a() {
    b()
    b2()
}


function b() {
    c1()
    c3()
}


function b2() {
    c1()
    c2()
    c3()
}


function c1() {
    return "c1"
}

function c2() {
    return "c2"
}


function c3() {
    return "c3"
}
```